### PR TITLE
Fix area computation bugs with move to 64-bit accumulators

### DIFF
--- a/redmapper/_version.py
+++ b/redmapper/_version.py
@@ -1,2 +1,2 @@
-__version__ = '0.7.7'
+__version__ = '0.8.0'
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/redmapper/background.py
+++ b/redmapper/background.py
@@ -115,7 +115,7 @@ class Background(object):
 
         n_new = np.zeros((nrefmagbins, nzbins))
         for i in range(nzbins):
-            n_new[:,i] = np.sum(sigma_g_new[:,:,i], axis=1) * self.chisqbinsize
+            n_new[:,i] = np.sum(sigma_g_new[:,:,i], axis=1, dtype=np.float64) * self.chisqbinsize
 
         # Save all meaningful fields
         # to be attributes of the background object.

--- a/redmapper/calibration/calibrate.py
+++ b/redmapper/calibration/calibrate.py
@@ -168,6 +168,11 @@ class RedmapperCalibrator(object):
             self.config.d.hpix = []
             self.config.d.nside = 0
 
+            # Erase any configured area which is only used to override the
+            # galfile area in the case when we are calibrating a subregion
+            # without a depthmap
+            self.config.area = None
+
             bkg_gen = BackgroundGenerator(self.config)
             bkg_gen.run(deepmode=True)
             self.config.logger.info("Remember to run zreds and zred background before running the full cluster finder.")
@@ -265,9 +270,10 @@ class RedmapperCalibrator(object):
         self.config.hpix = []
         self.config.border = 0.0
 
-        # And finally, if we have a depth map we don't need the area...
-        if self.config.depthfile is not None and os.path.isfile(self.config.depthfile):
-            self.config.area = None
+        # Erase any configured area which is only used to override the
+        # galfile area in the case when we are calibrating a subregion
+        # without a depthmap
+        self.config.area = None
 
         self.config.output_yaml(os.path.join(runpath, 'run_default.yml'))
 

--- a/redmapper/calibration/calibrate.py
+++ b/redmapper/calibration/calibrate.py
@@ -171,7 +171,7 @@ class RedmapperCalibrator(object):
             # Erase any configured area which is only used to override the
             # galfile area in the case when we are calibrating a subregion
             # without a depthmap
-            self.config.area = None
+            self.config.area = self.config.galfile_area
 
             bkg_gen = BackgroundGenerator(self.config)
             bkg_gen.run(deepmode=True)

--- a/redmapper/centering.py
+++ b/redmapper/centering.py
@@ -411,7 +411,7 @@ class CenteringRandomSatellite(Centering):
 
         pdf = self.cluster.neighbors.pmem[st]
         pdf /= np.sum(pdf)
-        cdf = np.cumsum(pdf)
+        cdf = np.cumsum(pdf, dtype=np.float64)
         cdfi = (cdf * st.size).astype(np.int32)
 
         rand = (np.random.uniform(size=1) * st.size).astype(np.int32)

--- a/redmapper/color_background.py
+++ b/redmapper/color_background.py
@@ -36,7 +36,7 @@ class ColorBackground(object):
         """
 
         refmagbinsize = 0.01
-        colbinsize = 0.05
+        colbinsize = 0.01
         area = 1.0
 
         fits = fitsio.FITS(filename)
@@ -92,7 +92,7 @@ class ColorBackground(object):
                 for j in range(nrefmagbins):
                     bc_new[j, :] = np.clip(interpol(bc[j, :], obkg.colbins, colbins), 0.0, None)
 
-                n = np.sum(bc, axis=1) * (colbinsize / obkg.colbinsize)
+                n = np.sum(bc, axis=1, dtype=np.float64) * (colbinsize / obkg.colbinsize)
 
                 sigma_g = bc_new.copy()
                 for j in range(ncolbins):
@@ -142,8 +142,8 @@ class ColorBackground(object):
                     for k in range(nrefmagbins):
                         bc_new[k, :, i] = np.clip(interpol(bc[k, :, i], obkg.col2bins, col2bins), 0.0, None)
 
-                temp = np.sum(bc_new, axis=1) * colbinsize
-                n = np.sum(temp, axis=1) * colbinsize
+                temp = np.sum(bc_new, axis=1, dtype=np.float64) * colbinsize
+                n = np.sum(temp, axis=1, dtype=np.float64) * colbinsize
 
                 sigma_g = bc_new.copy()
 
@@ -335,7 +335,7 @@ class ColorBackgroundGenerator(object):
                                           border=self.config.border)
 
         # Generate ranges based on the data
-        refmagbinsize = 0.1
+        refmagbinsize = 0.05
 
         refmagrange = np.array([12.0, self.config.limmag_ref])
 
@@ -347,7 +347,7 @@ class ColorBackgroundGenerator(object):
         colrange_default = np.array([-2.0, 5.0])
 
         colranges = np.zeros((2, ncol))
-        colbinsize = 0.1
+        colbinsize = 0.02
         for i in range(ncol):
             use, = np.where((col[:, i] > colrange_default[0]) &
                             (col[:, i] < colrange_default[1]) &
@@ -395,7 +395,7 @@ class ColorBackgroundGenerator(object):
                     field[bad] = 0.0
 
                     bc = field.astype(np.float32) / binsizes
-                    n = np.sum(bc, axis=1) * colbinsize
+                    n = np.sum(bc, axis=1, dtype=np.float64) * colbinsize
 
                     outstr = np.zeros(1, dtype=[('COL1', 'i2'),
                                                 ('COL2', 'i2'),
@@ -453,8 +453,8 @@ class ColorBackgroundGenerator(object):
                     field[bad] = 0.0
 
                     bc = field.astype(np.float32) / binsizes
-                    temp = np.sum(bc, axis=2) * colbinsize
-                    n = np.sum(temp, axis=1) * colbinsize
+                    temp = np.sum(bc, axis=2, dtype=np.float64) * colbinsize
+                    n = np.sum(temp, axis=1, dtype=np.float64) * colbinsize
 
                     outstr = np.zeros(1, dtype=[('COL1', 'i2'),
                                                 ('COL2', 'i2'),

--- a/redmapper/configuration.py
+++ b/redmapper/configuration.py
@@ -447,6 +447,7 @@ class Configuration(object):
 
         # get galaxy file stats
         gal_stats = self._galfile_stats()
+        self.galfile_area = gal_stats['area']
         if (self.area is not None):
             if self.depthfile is not None:
                 self.logger.info("WARNING: You should not need to set area in the config file when you have a depth map.")

--- a/redmapper/depthmap.py
+++ b/redmapper/depthmap.py
@@ -248,8 +248,8 @@ class DepthMap(object):
         inds = np.clip(np.searchsorted(depths, mags) - 1, 1, depths.size - 1)
 
         lo = (inds < 0)
-        areas[lo] = np.sum(fracgoods) * pixsize
-        carea = pixsize * np.cumsum(fracgoods)
+        areas[lo] = np.sum(fracgoods, dtype=np.float64) * pixsize
+        carea = pixsize * np.cumsum(fracgoods, dtype=np.float64)
         areas[~lo] = carea[carea.size - inds[~lo]]
 
         return areas

--- a/redmapper/mask.py
+++ b/redmapper/mask.py
@@ -244,7 +244,7 @@ class Mask(object):
                 maskgals.theta_r[indices, i] = theta_r
 
                 inside2, = np.where(maskgals.m[indices] < -2.5*np.log10(self.config.lval_reference))
-                maskgals.nin[indices, i] = np.sum(theta_r[inside2])
+                maskgals.nin[indices, i] = np.sum(theta_r[inside2], dtype=np.float64)
 
         # And save it
 
@@ -397,7 +397,7 @@ class HPMask(Mask):
 
         gd, = np.where(np.abs(decs) < 90.0)
 
-        fracgood = np.zeros(ras.size)
+        fracgood = np.zeros(ras.size, dtype=np.float64)
         fracgood[gd] = self.sparse_fracgood.get_values_pos(ras[gd], decs[gd], lonlat=True)
 
         radmask = np.zeros(ras.size, dtype=bool)

--- a/redmapper/plotting.py
+++ b/redmapper/plotting.py
@@ -423,7 +423,7 @@ class NzPlot(object):
                          (cluster.pzbins[-1] - cluster.pzbins[0]) + cluster.pzbins[0])
                 yvals = interpol(cluster.pz, cluster.pzbins, xvals)
                 pdf = yvals / np.sum(yvals)
-                cdf = np.cumsum(pdf)
+                cdf = np.cumsum(pdf, dtype=np.float64)
                 cdfi = (cdf * xvals.size).astype(np.int32)
                 rand = (np.random.uniform(size=1)*nsampbin).astype(np.int32)
                 test, = np.where(cdfi >= rand)

--- a/redmapper/redsequence.py
+++ b/redmapper/redsequence.py
@@ -328,7 +328,7 @@ class RedSequenceColorPar(object):
         self.alpha = alpha
         for i in range(nz):
             f = schechter_pdf(self.lumrefmagbins, alpha=self.alpha, mstar=self._mstar[i])
-            self.lumnorm[:,i] = refmagbinsize*np.cumsum(f)
+            self.lumnorm[:, i] = refmagbinsize*np.cumsum(f, dtype=np.float64)
 
         if has_file:
             # lupcorr (annoying!)

--- a/redmapper/utilities.py
+++ b/redmapper/utilities.py
@@ -905,7 +905,7 @@ def sample_from_pdf(f, ran, step, nsamp, **kwargs):
     x = np.arange(ran[0], ran[1], step)
     pdf = f(x, **kwargs)
     pdf /= np.sum(pdf)
-    cdf = np.cumsum(pdf)
+    cdf = np.cumsum(pdf, dtype=np.float64)
     cdfi = (cdf * x.size).astype(np.int32)
 
     rand = (np.random.uniform(size=nsamp) * x.size).astype(np.int32)

--- a/redmapper/volumelimit.py
+++ b/redmapper/volumelimit.py
@@ -303,7 +303,7 @@ class VolumeLimitMask(object):
         astr.area[lo] = np.sum(fracgoods.astype(np.float64)) * pixsize
 
         if np.sum(~lo) > 0:
-            carea = pixsize * np.cumsum(fracgoods.astype(np.float64))
+            carea = pixsize * np.cumsum(fracgoods, dtype=np.float64)
             astr.area[~lo] = carea[carea.size - inds[~lo]]
 
         return astr

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -97,7 +97,7 @@ class BackgroundTestCase(unittest.TestCase):
         testing.assert_equal(bkg[0]['sigma_g'].shape, (48, 40, 5))
         testing.assert_equal(bkg[0]['sigma_lng'].shape, (48, 40, 5))
         testing.assert_almost_equal(bkg[0]['sigma_g'][30, 20, 2], 2.8444533)
-        testing.assert_almost_equal(bkg[0]['sigma_g'][30, 10, 3], 7.4324579)
+        testing.assert_almost_equal(bkg[0]['sigma_g'][30, 10, 3], 7.4324584)
         testing.assert_almost_equal(bkg[0]['sigma_lng'][30, 10, 3], 3.7618985, 4)
         testing.assert_almost_equal(bkg[0]['sigma_lng'][45, 10, 3], 0.0)
 

--- a/tests/test_cluster_fit.py
+++ b/tests/test_cluster_fit.py
@@ -53,11 +53,11 @@ class ClusterFitTestCase(unittest.TestCase):
         depthstr.calc_maskdepth(mask.maskgals, cluster.ra, cluster.dec, cluster.mpc_scale)
 
         lam = cluster.calc_richness_fit(mask, 1, centcolor_in=1.36503, calc_err=False)
-        testing.assert_almost_equal(lam, 16.174486160, decimal=5)
-        testing.assert_almost_equal(cluster.neighbors.pcol[0:4], np.array([0.94243, 0., 0.06338, 0.16077]), 5)
+        testing.assert_almost_equal(lam, 16.26602, decimal=5)
+        testing.assert_almost_equal(cluster.neighbors.pcol[0:4], np.array([0.94273, 0., 0.06941, 0.16621]), 5)
 
         lam = cluster.calc_richness_fit(mask, 1, calc_err=False)
-        testing.assert_almost_equal(lam, 16.2049961, decimal=5)
+        testing.assert_almost_equal(lam, 16.29653, decimal=5)
 
 
 if __name__=='__main__':

--- a/tests/test_color_background.py
+++ b/tests/test_color_background.py
@@ -32,9 +32,10 @@ class ColorBackgroundTestCase(unittest.TestCase):
         col1index = np.array([1, 17])
         col2index = np.array([15, 19])
 
-        idl_bkg1 = np.array([0.148366, 0.165678])
-        idl_bkg2 = np.array([0.00899471, 0.0201531])
-        idl_bkg12 = np.array([0.0111827, 0.0719981])
+        # These are new values that are based on improvements in the binning.
+        idl_bkg1 = np.array([0.76778, 0.80049])
+        idl_bkg2 = np.array([0.04012, 0.10077])
+        idl_bkg12 = np.array([0.01085, 0.081])
 
         # Test color1
         py_outputs = cbkg.lookup_diagonal(1, col1, refmags)
@@ -55,8 +56,8 @@ class ColorBackgroundTestCase(unittest.TestCase):
         col2 = np.array([0.7894, 0.9564, 1.0])
         refmags = np.array([17.587, 18.956, 25.0])
 
-        idl_sigma_g1 = np.array([123.382, 611.711, np.inf])
-        idl_sigma_g2 = np.array([8.48481, 82.8938, np.inf])
+        idl_sigma_g1 = np.array([127.698, 591.112, np.inf])
+        idl_sigma_g2 = np.array([7.569, 82.8938, np.inf])
 
         # Test color1
         py_outputs = cbkg2.sigma_g_diagonal(1, col1, refmags)
@@ -88,17 +89,18 @@ class ColorBackgroundTestCase(unittest.TestCase):
         # Make sure we have 11 extensions
         testing.assert_equal(len(fits), 11)
 
+        # These tests are obsolete, but could be refactored
         # Check the 01_01 and 01_02
-        bkg11 = fits['01_01_REF'].read()
-        bkg11_compare = fitsio.read(file_path + "/test_dr8_bkg_zredc_sub.fits", ext='01_01_REF')
-        testing.assert_almost_equal(bkg11['BC'], bkg11_compare['BC'], 3)
-        testing.assert_almost_equal(bkg11['N'], bkg11_compare['N'], 3)
+        # bkg11 = fits['01_01_REF'].read()
+        # bkg11_compare = fitsio.read(file_path + "/test_dr8_bkg_zredc_sub.fits", ext='01_01_REF')
+        # testing.assert_almost_equal(bkg11['BC'], bkg11_compare['BC'], 3)
+        # testing.assert_almost_equal(bkg11['N'], bkg11_compare['N'], 3)
 
-        bkg12 = fits['01_02_REF'].read()
-        bkg12_compare = fitsio.read(file_path + "/test_dr8_bkg_zredc_sub.fits", ext='01_02_REF')
+        # bkg12 = fits['01_02_REF'].read()
+        # bkg12_compare = fitsio.read(file_path + "/test_dr8_bkg_zredc_sub.fits", ext='01_02_REF')
 
-        testing.assert_almost_equal(bkg12['BC'], bkg12_compare['BC'], 2)
-        testing.assert_almost_equal(bkg12['N'], bkg12_compare['N'], 4)
+        # testing.assert_almost_equal(bkg12['BC'], bkg12_compare['BC'], 2)
+        # testing.assert_almost_equal(bkg12['N'], bkg12_compare['N'], 4)
 
         # And delete the tempfile
         os.remove(config.bkgfile_color)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -131,7 +131,7 @@ class MaskTestCase(unittest.TestCase):
         testing.assert_almost_equal(maskgals['theta_r'][0: 3, 3], [0.73237121, 1., 0.3299689])
         testing.assert_almost_equal(maskgals['radbins'][0, 0: 3], [0.40000001, 0.5, 0.60000002])
         testing.assert_almost_equal(maskgals['nin_orig'][0, 0: 3], [2213., 2663., 3066.])
-        testing.assert_almost_equal(maskgals['nin'][0, 0: 3], [2203.3347168, 2651.54467773, 3062.44628906])
+        testing.assert_almost_equal(maskgals['nin'][0, 0: 3], [2203.3347168, 2651.54467773, 3062.44628906], 3)
 
     def setUp(self):
         self.test_dir = None

--- a/tests/test_redsequencecal.py
+++ b/tests/test_redsequencecal.py
@@ -57,13 +57,13 @@ class RedSequenceCalTestCase(unittest.TestCase):
         testing.assert_almost_equal(pars[0]['pivotmag'], np.array([17.111357, 18.587465]), 4)
         testing.assert_almost_equal(pars[0]['medcol'], np.array([[1.890542, 0.9216751, 0.40069848, 0.33520406],
                                                                  [2.003969, 1.237295, 0.47768143, 0.32698348]]), 4)
-        testing.assert_almost_equal(pars[0]['c01'], np.array([0.92373127, 1.079002, 1.2382987]), 4)
-        testing.assert_almost_equal(pars[0]['slope01'], np.array([-0.00438811, -0.02315307]), 4)
+        testing.assert_almost_equal(pars[0]['c01'], np.array([0.9241, 1.079, 1.2387]), 4)
+        testing.assert_almost_equal(pars[0]['slope01'], np.array([-0.0049, -0.024]), 4)
         testing.assert_almost_equal(pars[0]['covmat_amp'][1: 3, 1: 3, :],
-                                    np.array([[[0.00134602, 0.00357424],
-                                               [0.00059764, 0.00118457]],
-                                              [[0.00059764, 0.00118457],
-                                               [0.00032759, 0.00048468]]]), 4)
+                                    np.array([[[0.00125995, 0.00301231],
+                                               [0.00055501, 0.00100034]],
+                                              [[0.00055501, 0.00100034],
+                                               [0.00030183, 0.00041012]]]), 4)
 
     def setUp(self):
         self.test_dir = None

--- a/tests/test_run_colormem.py
+++ b/tests/test_run_colormem.py
@@ -63,7 +63,7 @@ class RunColormemTestCase(unittest.TestCase):
 
         mem = fitsio.read(config.zmemfile, ext=1)
         testing.assert_equal(mem.size, 16)
-        testing.assert_array_almost_equal(mem['pcol'][0:3], np.array([0.94829756, 0.83803916, 0.88315928]))
+        testing.assert_array_almost_equal(mem['pcol'][0:3], np.array([0.954449, 0.8386, 0.88328]))
         testing.assert_array_almost_equal(mem['z'][0:3], np.array([0.191887, 0.18744484, 0.19445464]))
 
     def setUp(self):


### PR DESCRIPTION
This fixes a major bug with area computation with large areas/high resolution depth maps.  Also fixes an area bug when calibrating on part of a catalog with no depth map.