### PR TITLE
Changes for TXPipe

### DIFF
--- a/redmapper/redmagic/redmagic_selector.py
+++ b/redmapper/redmagic/redmagic_selector.py
@@ -33,7 +33,7 @@ class RedmagicSelector(object):
             Random number generator.
         """
 
-        if not isinstance(conf, Configuration):
+        if isinstance(conf, str):
             self.config = Configuration(conf)
         else:
             self.config = conf

--- a/tests/test_redmagic.py
+++ b/tests/test_redmagic.py
@@ -204,6 +204,8 @@ class RedmagicCalTestCase(unittest.TestCase):
         self.test_dir = None
 
     def tearDown(self):
+        if "TXPIPE_NO_DELETE" in os.environ:
+            return
         if self.test_dir is not None:
             if os.path.exists(self.test_dir):
                 shutil.rmtree(self.test_dir, True)


### PR DESCRIPTION
This is a work-in-progress of changes that I'm finding are needed to run the RedMagic selection within TXPipe. Ignore it for now, it's just for me to keep track.  I'll update it as I find other issues.

So far:
- I needed an example redmagic calibration file for testing, so added an option (powered by an environment variable) to keep the one generated during testing
- The Configuration in RedMapper requires many options that are not needed as part of the RedMagic selection, only for earlier stages. I made it possible to use an alternative and more limited configuration object.